### PR TITLE
feat: ability to customize text in theme

### DIFF
--- a/demo/_data.yml
+++ b/demo/_data.yml
@@ -9,3 +9,9 @@ metas:
   description: This is an example of a Lume blog theme
   twitter: "@misteroom"
   lang: "=lang"
+
+mergedKeys:
+  static_text: object
+
+static_text:
+  toc_name: Table of Contents

--- a/demo/posts/germanpost.md
+++ b/demo/posts/germanpost.md
@@ -1,0 +1,44 @@
+---
+title: This post shows how to localize some of the static text
+date: 2023-05-07
+author: Reed von Redwitz
+excerpt: Read on if you want to change "Table of Contents", "Older post", and other stuff!
+tags:
+  - Instructions
+static_text:
+    toc_name: Inhalt
+    next_post: neuerer Beitrag →
+    previous_post: ← vorheriger Beitrag
+    by: von
+    reading_time: Minuten Lesezeit
+---
+
+Look, the content of this is in English, but the markup of the page has changed to German. Instead of "Table of Contents" we now have "Inhalt". And people say that German words are so much longer! How can you do the same?
+
+<!--more-->
+
+## Overrides within a Post
+In the front matter for a specific post you can do something like this:
+```md
+static_text:
+    toc_name: Inhalt
+    next_post: neuerer Beitrag →
+    previous_post: ← vorheriger Beitrag
+    by: von
+    reading_time: Minuten Lesezeit
+```
+(These are currently all the overrides that are available.) You should probably pick different words, unless your site is in German.
+
+## Overrides for the Site
+That's a bit annoying though, as per the DRY principle. So of course we can leverage the [Shared data](https://lume.land/docs/creating-pages/shared-data/) feature, built right into Lume. In the `_data.yml` at the root level, I have the following defined:
+```md
+mergedKeys:
+  static_text: object
+
+static_text:
+  toc_name: Table of Contents
+```
+
+Why? Simply to demonstrate two things:
+1. That shared data actually works with this feature.
+2. That I can successfully override something on a particular page. Confused about `mergedKeys`? You obviously haven't read the [documentation](https://lume.land/docs/core/merged-keys/) enough times. Get to it!

--- a/demo/posts/secondpost.md
+++ b/demo/posts/secondpost.md
@@ -37,3 +37,10 @@ Capitalize on low hanging fruit to identify a ballpark value added activity to
 beta test. Override the digital divide with additional clickthroughs from
 DevOps. Nanotechnology immersion along the information highway will close the
 loop on focusing solely on the bottom line.
+
+### Other Header
+
+Capitalize on low hanging fruit to identify a ballpark value added activity to
+beta test. Override the digital divide with additional clickthroughs from
+DevOps. Nanotechnology immersion along the information highway will close the
+loop on focusing solely on the bottom line.

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -11,7 +11,7 @@ bodyClass: body-post
 
   {% if toc.length > 1 or toc[0].children.length %}
   <nav class="toc">
-    <h2>Table of contents</h2>
+    <h2>{{ static_text.toc_name|default("Table of Contents") }}</h2>
     <ol>
       {% for item in toc %}
       <li>
@@ -43,7 +43,7 @@ bodyClass: body-post
     {%- if previousPost %}
     <li class="pagination-prev">
       <a href="{{ previousPost.data.url }}" rel="prev">
-        <span>← Older post</span>
+        <span>{{ static_text.previous_post|default("← Older post") }}</span>
         <strong>{{ previousPost.data.title }}</strong>
       </a>
     </li>
@@ -53,7 +53,7 @@ bodyClass: body-post
     {%- if nextPost %}
     <li class="pagination-next">
       <a href="{{ nextPost.data.url }}" rel="next">
-        <span>Newer post →</span>
+        <span>{{ static_text.next_post|default("Newer post →") }}</span>
         <strong>{{ nextPost.data.title }}</strong>
       </a>
     </li>

--- a/src/_includes/templates/post-details.njk
+++ b/src/_includes/templates/post-details.njk
@@ -2,9 +2,9 @@
   {% if author %}
     {% set page = search.page("type=author author='" + author + "'") %}
     {% if page %}
-      <p>By <a data-pagefind-filter="author" href="{{ page.data.url }}">{{ author }}</a></p>
+      <p>{{ static_text.by|default("By") }} <a data-pagefind-filter="author" href="{{ page.data.url }}">{{ author }}</a></p>
     {% else %}
-      <p>By {{ author }}</p>
+      <p>{{ static_text.by|default("By") }} {{ author }}</p>
     {% endif %}
   {% endif %}
 
@@ -14,7 +14,7 @@
     </time>
   </p>
 
-  <p>{{ readingTime.minutes }} min read</p>
+  <p>{{ readingTime.minutes }} {{ static_text.reading_time|default("min read") }}</p>
 
   <div class="post-tags">
     {% for tag in tags %}


### PR DESCRIPTION
This seems like a great theme out of the box, but the only issue is that I'm making a site in German. I wanted some of the static text to be configurable (e.g. `Table of Contents` -> `Inhalt`).

I did this by copying the `post.njk` and `post-details.njk` files to my local project and changing them there, but I realized this causes two issues:
1. if you change things then I've now diverged from upstream
2. it doesn't solve the problem for anyone else

So here's an attempt at a small amount of configurability. I've added a post to the demo project describing what's going on in detail. Basically you can override the following five values:
1. toc_name
2. next_post
3. previous_post
4. by
5. reading_time:

Please let me know if this isn't at all the direction you want to take things in this repo, or if the implementation should get changed.