### PR TITLE
fix: error when post is plain text without titles

### DIFF
--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -9,7 +9,7 @@ bodyClass: body-post
     {{ include "templates/post-details.vto" }}
   </header>
 
-  {{ if toc.length > 1 || toc[0].children.length }}
+  {{ if toc.length > 1 || (toc[0] && toc[0].children.length) }}
   <nav class="toc">
     <h2>Table of contents</h2>
     <ol>


### PR DESCRIPTION
Compilation fails for posts without titles or subtitles because toc.length is 0. In the condition:
```
  {{ if toc.length > 1 || toc[0].children.length }}
```

The first part is false, so the second condition is evaluated. However, this fails because toc[0] is undefined. Therefore, it is necessary to check for the existence of toc[0].

Thanks for the :fire: :fire: !!