### PR TITLE
Optional logo, as metas.site can't have html tags

### DIFF
--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -19,7 +19,11 @@
   <body>
     <nav class="navbar">
       <a href="/" class="navbar-home">
-        <strong>{{ it.logo || metas.site }}</strong>
+        {{ if it.logo }}
+          {{ it.logo }}
+        {{ else }}
+          <strong>{{ metas.site }}</strong>
+        {{ /if }}
       </a>
 
       <ul class="navbar-links">

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -19,7 +19,7 @@
   <body>
     <nav class="navbar">
       <a href="/" class="navbar-home">
-        <strong>{{ metas.site }}</strong>
+        <strong>{{ it.logo || metas.site }}</strong>
       </a>
 
       <ul class="navbar-links">


### PR DESCRIPTION
If you want to add html content as a logo in the value of metas.site, this breaks the feed plugin as the same value is used for the title property.

I've added an optional it.logo as to not break the feed plugin, and be able to show html tags.