### PR TITLE
SEO: canonical URL and deps: Update lume and reload cache

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,12 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.0.0/"
+    "lume/": "https://deno.land/x/lume@v2.0.1/"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s",
+    "reload": "echo \"import 'lume/cli.ts'\" | deno run --reload --unstable -A -",
     "changelog": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.1.0/bin.ts"
   },
   "compilerOptions": {

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,6 @@
     "lume": "echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s",
-    "reload": "echo \"import 'lume/cli.ts'\" | deno run --reload --unstable -A -",
     "changelog": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.1.0/bin.ts"
   },
   "compilerOptions": {

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -14,7 +14,7 @@
     <link rel="alternate" href="/feed.xml" type="application/atom+xml" title="{{ metas.site }}">
     <link rel="alternate" href="/feed.json" type="application/json" title="{{ metas.site }}">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-    <link rel="canonical" href="{{ url | url(true) }}">
+    <link rel="canonical" href="{{ url |> url(true) }}">
     <script src="/js/main.js" type="module"></script>
     {{ it.extra_head || "" }}
   </head>

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -14,6 +14,7 @@
     <link rel="alternate" href="/feed.xml" type="application/atom+xml" title="{{ metas.site }}">
     <link rel="alternate" href="/feed.json" type="application/json" title="{{ metas.site }}">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
+    <link rel="canonical" href="{{ url | url(true) }}">
     <script src="/js/main.js" type="module"></script>
     {{ it.extra_head || "" }}
   </head>


### PR DESCRIPTION
- canonical URL in the header it applies to all pages/posts

using url filter - <https://lume.land/plugins/url/>
testing on my lume sites no issues

```js
<link rel="canonical" href="{{ url |> url(true) }}">
````