### PR TITLE
Fix: missing post toc i18n

### DIFF
--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -11,7 +11,7 @@ bodyClass: body-post
 
   {{ if toc.length }}
   <nav class="toc">
-    <h2>Table of contents</h2>
+    <h2>{{ i18n.nav.toc }}</h2>
     <ol>
       {{ for item of toc }}
       <li>


### PR DESCRIPTION
The i18n for the TOC is missing in the post template. 😃 