### PR TITLE
Feat: add target as menu link option

### DIFF
--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -38,7 +38,7 @@
       {{ /for }}
       {{- for link of it.menu_links }}
         <li>
-          <a href="{{ link.href }}">
+          <a href="{{ link.href }}"{{ if link.target }} target="{{link.target}}"{{ /if }}>
             {{ link.text }}
           </a>
         </li>


### PR DESCRIPTION
I particularly think that quite often user might need a menu link to open externally (Linkedin, Github, X, Linktree, etc).

This option enables an extra "target" option for link.

```js
menu_links:
  [
    { text: "Github", href: "https://github.com/niltonheck", target: "_blank" },
    {
      text: "Linkedin",
      href: "https://www.linkedin.com/in/niltonheck/",
      target: "_blank",
    },
  ]
```