### PR TITLE
Fix: missing archive i18n

### DIFF
--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -3,6 +3,7 @@ nav:
   next_post: Newer post →
   previous_post: ← Older post
   continue_reading: Continue reading →
+  archive_title: Archive
   archive: More posts can be found in <a href="/archive/">the archive</a>.
   back: ← Back
   page: Page
@@ -12,8 +13,8 @@ post:
   by: by
   reading_time: min read
 search:
-  by_author: Posts by 
-  by_tag: Tagged 
+  by_author: Posts by
+  by_tag: Tagged
   tags: Tags
 comments:
   title: Comments

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -13,8 +13,8 @@ post:
   by: by
   reading_time: min read
 search:
-  by_author: Posts by
-  by_tag: Tagged
+  by_author: Posts by 
+  by_tag: Tagged 
   tags: Tags
 comments:
   title: Comments

--- a/src/archive.page.js
+++ b/src/archive.page.js
@@ -1,7 +1,6 @@
 export const layout = "layouts/archive.vto";
-export const title = "Archive";
 
-export default function* ({ search, paginate }) {
+export default function* ({ search, paginate, i18n }) {
   const posts = search.pages("type=post", "date=desc");
 
   for (
@@ -15,7 +14,10 @@ export default function* ({ search, paginate }) {
       };
     }
 
-    yield data;
+    yield {
+      ...data,
+      title: i18n.nav.archive_title
+    };
   }
 }
 


### PR DESCRIPTION
A small fix to allow `Archive` title to be properly translated.