### PR TITLE
Cutting down the character count in the Postlist and resolving the issue where Mastodon comments display incorrectly on smartphones.

### DIFF
--- a/src/index.vto
+++ b/src/index.vto
@@ -29,7 +29,7 @@ title: Home
     </header>
 
     <div class="post-excerpt body">
-      {{ post.excerpt |> slice(0, 100) |> md }}
+      {{ post.excerpt |> md }}
     </div>
 
     <a href="{{ post.url }}" class="post-link">

--- a/src/index.vto
+++ b/src/index.vto
@@ -29,7 +29,7 @@ title: Home
     </header>
 
     <div class="post-excerpt body">
-      {{ post.excerpt |> md }}
+      {{ post.excerpt |> slice(0, 100) |> md }}
     </div>
 
     <a href="{{ post.url }}" class="post-link">

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,4 +28,8 @@ main {
 /* Search tweak */
 .search {
   margin-top: var(--row-gap-xsmall);
+
+/* Comments Layout*/
+.comments {
+  display: contents;
 }


### PR DESCRIPTION
demo

https://soulminingrig.com/

![image](https://github.com/user-attachments/assets/89d2db57-44a6-4772-86dc-f43a087285ad)
`src/index.vto`
i made sure that the articles on the homepage are properly trimmed and displayed neatly when posted.

## before

`PC` Okay...
![image](https://github.com/user-attachments/assets/f7aa0f6f-2b5b-4937-b25c-55896105fbc2)

`smartphone` aaaa!!
![image](https://github.com/user-attachments/assets/4b805dd0-a080-44f4-a10e-dc82329a9902)

## after
`src/style.css`
```
.comments {
  display: contents;
}
```
`PC`
![image](https://github.com/user-attachments/assets/55323910-8b75-4dd0-ae87-1a85d932964f)

`smartphone` 
![image](https://github.com/user-attachments/assets/6a344cbf-0393-46fd-b40b-50075d52f789)
