### PR TITLE
Docs: lume init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ URL:
 
 ```ts
 import lume from "lume/mod.ts";
-import blog from "https://deno.land/x/lume_theme_simple_blog@v0.15.6/mod.ts";
+import blog from "https://deno.land/x/lume_theme_simple_blog/mod.ts";
 
 const site = lume();
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default site;
 ```
 
 Copy the [`_data.yml`](./src/_data.yml) file to your blog root folder and edit
-it with your data to customize the site title, description, and metadata.
+it with your data.
 
 ## Use it as a base template
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,38 @@
 
 [Lume](https://lume.land) theme to create a simple blog.
 
-- It supports tags and post authors.
-- RSS (Atom and JSON).
-- Sitemap and SEO features.
-- Instant search engine.
+- Supports tags and post authors
+- Atom and JSON feeds
+- Sitemap and SEO features
+- Instant search engine
+
+## Set up a new site
+
+The **fastest and easiest** way to configure this theme is the
+[Lume init command](https://deno.land/x/lume_init@v0.2.7), which one can also
+copy easily from the
+[Simple Blog theme page](https://lume.land/theme/simple-blog/). Running:
+
+```bash
+deno run -A https://lume.land/init.ts --theme=simple-blog
+```
+
+will create a new project with Simple Blog configured. Edit the
+[`_data.yml`](./src/_data.yml) file in your blog root folder with your data to
+customize the site title, description, and metadata.
+
+Posts must be saved in the `posts` folder. For example,
+`posts/my-first-posts.md`.
 
 ## Install as a remote theme
 
-The **fastest and easiest** way to use this theme is by importing it as a remote
-module. It allows to create a blog in seconds and update it at any time just by
-changing the version number in the import URL. Just add the following code to
-your `_config.ts` file:
+To add the theme to an existing Lume project, import it in your `_config.ts`
+file as a remote module. Update it by changing the version number in the import
+URL:
 
 ```ts
 import lume from "lume/mod.ts";
-import blog from "https://deno.land/x/lume_theme_simple_blog@v0.10.2/mod.ts";
+import blog from "https://deno.land/x/lume_theme_simple_blog@v0.15.6/mod.ts";
 
 const site = lume();
 
@@ -25,13 +42,11 @@ site.use(blog());
 export default site;
 ```
 
-You can see an example in the [demo](./demo) folder. To customize it copy the
-[`_data.yml`](./src/_data.yml) file in your blog root folder and edit it with
-your data. The posts must be saved in the `posts` folder. For example
-`posts/`my-first-posts.md`.
+Copy the [`_data.yml`](./src/_data.yml) file to your blog root folder and edit
+it with your data to customize the site title, description, and metadata.
 
 ## Use it as a base template
 
 To use this theme as a base template for a more customized blog, clone this repo
-and edit the [_config.ts](./_config.ts) file. The source files are in the
-[src](./src/) folder. And you can remove the `/demo` folder.
+and edit the [\_config.ts](./_config.ts) file. The source files are in the
+[src](./src/) folder.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ URL:
 
 ```ts
 import lume from "lume/mod.ts";
-import blog from "https://deno.land/x/lume_theme_simple_blog/mod.ts";
+import blog from "https://deno.land/x/lume_theme_simple_blog@v0.15.6/mod.ts";
 
 const site = lume();
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 ## Set up a new site
 
 The **fastest and easiest** way to configure this theme is the
-[Lume init command](https://deno.land/x/lume_init@v0.2.7), which one can also
-copy easily from the
-[Simple Blog theme page](https://lume.land/theme/simple-blog/). Running:
+[Lume init command](https://deno.land/x/lume_init), which one can also copy
+easily from the [Simple Blog theme page](https://lume.land/theme/simple-blog/).
+Running:
 
 ```bash
 deno run -A https://lume.land/init.ts --theme=simple-blog

--- a/src/posts/instructions.md
+++ b/src/posts/instructions.md
@@ -13,7 +13,7 @@ provides Atom and JSON feeds for your subscribers.
 <!--more-->
 
 The **fastest and easiest** way to configure this theme is the
-[Lume init command](https://deno.land/x/lume_init), which one can also copy
+[Lume init command](https://deno.land/x/lume_init), which you can also copy
 easily from the [Simple Blog theme page](https://lume.land/theme/simple-blog/).
 Running:
 
@@ -53,5 +53,5 @@ file to your blog root folder and edit it with your data.
 
 > [!tip]
 >
-> Use [lumeCMS](https://lume.land/cms) to customize the blog and add content
-> easily
+> You can use [lumeCMS](https://lume.land/cms) to customize the blog and add
+> content easily

--- a/src/posts/instructions.md
+++ b/src/posts/instructions.md
@@ -36,7 +36,7 @@ URL:
 
 ```ts
 import lume from "lume/mod.ts";
-import blog from "https://deno.land/x/lume_theme_simple_blog/mod.ts";
+import blog from "https://deno.land/x/lume_theme_simple_blog@v0.15.6/mod.ts";
 
 const site = lume();
 

--- a/src/posts/instructions.md
+++ b/src/posts/instructions.md
@@ -7,26 +7,51 @@ tags:
 ---
 
 **Simple blog** is a clean and minimal blog theme for Lume, with support for
-tags and authors. It allows to build your own blog **in seconds**, providing
-also support for RSS.
+tags and authors. It allows you to build your own blog **in seconds**, and
+provides Atom and JSON feeds for your subscribers.
 
 <!--more-->
 
-To use it, just import the theme in your `_config.ts` file:
+The **fastest and easiest** way to configure this theme is the
+[Lume init command](https://deno.land/x/lume_init), which one can also copy
+easily from the [Simple Blog theme page](https://lume.land/theme/simple-blog/).
+Running:
 
-```js
-import lume from "lume";
+```bash
+deno run -A https://lume.land/init.ts --theme=simple-blog
+```
+
+will create a new project with Simple Blog configured. Edit the `_data.yml` file
+in your blog root folder with your data to customize the site title,
+description, and metadata.
+
+Posts must be saved in the `posts` folder. For example,
+`posts/my-first-posts.md`.
+
+## Install as a remote theme
+
+To add the theme to an existing Lume project, import it in your `_config.ts`
+file as a remote module. Update it by changing the version number in the import
+URL:
+
+```ts
+import lume from "lume/mod.ts";
 import blog from "https://deno.land/x/lume_theme_simple_blog/mod.ts";
 
 const site = lume();
+
 site.use(blog());
 
 export default site;
 ```
 
+Copy the
+[`_data.yml`](https://github.com/lumeland/theme-simple-blog/blob/main/src/_data.yml)
+file to your blog root folder and edit it with your data.
+
 ## Customization
 
 > [!tip]
 >
-> You can use [lumeCMS](https://lume.land/cms) to customize the blog and add
-> content easily
+> Use [lumeCMS](https://lume.land/cms) to customize the blog and add content
+> easily


### PR DESCRIPTION
Closes #30 

Notes: 

- Saying [feeds instead of RSS](https://danielmiessler.com/p/atom-rss-why-we-should-just-call-them-feeds-instead-of-rss-feeds) since we use Atom and JSON.
- Added a link to the **init command** at https://deno.land/x/lume_init after reading https://lume.land/init.ts, in addition to link to theme page.
- Left **Install as a remote theme** in there for now and tried to separate the instructions accordingly.
- Going through these steps makes me wonder if we could scaffold out the `posts` folder with an example post for people when they run `deno run -A https://lume.land/init.ts --theme=simple-blog`. Would make things easier to describe here.