### PR TITLE
Add author to CMS

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -88,6 +88,7 @@ cms.collection(
   [
     "title: text",
     url,
+    "author: text",
     "date: date",
     {
       name: "draft",


### PR DESCRIPTION
Makes `author` editable in LumeCMS.