### PR TITLE
Remove whitespace in `.post-details p time` to prevent extra space

### DIFF
--- a/src/_includes/templates/post-details.vto
+++ b/src/_includes/templates/post-details.vto
@@ -8,11 +8,7 @@
     {{ /if }}
   {{ /if }}
 
-  <p>
-    <time datetime="{{ date |> date('DATETIME') }}">
-      {{ date |> date('HUMAN_DATE') }}
-    </time>
-  </p>
+  <p><time datetime="{{ date |> date('DATETIME') }}">{{ date |> date('HUMAN_DATE') }}</time></p>
 
   <p>{{ it.readingInfo.minutes }} {{ i18n.post.reading_time}}</p>
 


### PR DESCRIPTION
Remove whitespace in `.post-details p time` to prevent extra space 

- https://github.com/famebot/xeo/pull/15#issuecomment-2840433085
- https://github.com/famebot/xeo/pull/16/files