### PR TITLE
Bump deps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,14 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v3.0.0/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
-    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
+    "lume/": "https://deno.land/x/lume@v3.0.4/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.12.0/",
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s",
-    "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.8/cli.ts' update plugins.ts deno.json",
+    "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update plugins.ts deno.json",
     "cms": "deno task lume cms"
   },
   "compilerOptions": {

--- a/plugins.ts
+++ b/plugins.ts
@@ -11,10 +11,10 @@ import sitemap from "lume/plugins/sitemap.ts";
 import feed, { Options as FeedOptions } from "lume/plugins/feed.ts";
 import readingInfo from "lume/plugins/reading_info.ts";
 import { merge } from "lume/core/utils/object.ts";
-import toc from "https://deno.land/x/lume_markdown_plugins@v0.8.0/toc.ts";
-import image from "https://deno.land/x/lume_markdown_plugins@v0.8.0/image.ts";
-import footnotes from "https://deno.land/x/lume_markdown_plugins@v0.8.0/footnotes.ts";
-import { alert } from "npm:@mdit/plugin-alert@0.14.0";
+import toc from "https://deno.land/x/lume_markdown_plugins@v0.9.0/toc.ts";
+import image from "https://deno.land/x/lume_markdown_plugins@v0.9.0/image.ts";
+import footnotes from "https://deno.land/x/lume_markdown_plugins@v0.9.0/footnotes.ts";
+import { alert } from "npm:@mdit/plugin-alert@0.22.0";
 
 import "lume/types.ts";
 


### PR DESCRIPTION
Tried to update to Lume 3.0.4 but getting a Prism error now: 

```
Task serve deno task lume -s
Task lume echo "import 'lume/cli.ts'" | deno run -A - "-s"
Loading config file file:///lume/simple-blog/_config.ts
error: Uncaught (in worker "") (in promise) ReferenceError: self is not defined
    at Object.<anonymous> (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/prismjs/1.30.0/prism.js:11:48)
    at Object.<anonymous> (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/prismjs/1.30.0/prism.js:1948:4)
    at Module._compile (node:module:747:34)
    at loadMaybeCjs (node:module:772:10)
    at Object.Module._extensions..js (node:module:757:12)
    at Module.load (node:module:664:32)
    at Module._load (node:module:536:12)
    at Module.require (node:module:683:19)
    at require (node:module:818:16)
    at file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/prismjs/1.30.0/prism.js:7:17
error: Uncaught (in promise) Error: Unhandled error in child worker.
    at Worker.#pollControl (ext:runtime/11_workers.js:204:19)
    at eventLoopTick (ext:core/01_core.js:178:7)
```