### PR TITLE
Resolves issue where menu_links added through the CMS don't display.

### DIFF
--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -38,8 +38,8 @@
       {{ /for }}
       {{- for link of it.menu_links }}
         <li>
-          <a href="{{ link.href }}"{{ if link.target }} target="{{link.target}}"{{ /if }}>
-            {{ link.text }}
+          <a href="{{ link.url }}"{{ if link.target }} target="{{link.target}}"{{ /if }}>
+            {{ link.title }}
           </a>
         </li>
       {{ /for }}


### PR DESCRIPTION
Template references incorrect values for the link label and URL value. 

Let me know if I need to make any changes!